### PR TITLE
Fix missing closing characters in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ gpg --export-ownertrust > pgp-ownertrust.asc
 gpg --import pgp-public-keys.asc
 gpg --import pgp-private-keys.asc
 gpg --import-ownertrust pgp-ownertrust.asc```
+```
 
 # Debuging
 


### PR DESCRIPTION
I noticed you were missing something. The formatting looked awkward.